### PR TITLE
Removing references to cyhy_stakeholder

### DIFF
--- a/report.sh
+++ b/report.sh
@@ -23,7 +23,6 @@ sed -i 's/buf_size = 200000/buf_size = 400000/' /usr/share/texmf/web2c/texmf.cnf
 
 echo "Creating reporting folders..."
 mkdir -p $SHARED_DIR/artifacts/reporting/pshtt_reports
-mkdir -p $SHARED_DIR/artifacts/reporting/pshtt_non-cyhy_reports
 
 # Generate agency reports
 cd $SHARED_DIR/artifacts/reporting/pshtt_reports

--- a/report/generate_https_scan_report.py
+++ b/report/generate_https_scan_report.py
@@ -106,7 +106,6 @@ class ReportGenerator(object):
         self.__hsts_base_domain_preloaded_count = 0
         self.__hsts_low_max_age_count = 0
         # self.__report_oid = ObjectId()
-        self.__cyhy_stakeholder = False
 
         # Get list of all domains from the database
         all_domains_cursor = self.__db.https_scan.find({'latest':True, 'agency.name': agency})
@@ -157,9 +156,6 @@ class ReportGenerator(object):
 
     def __score_domain(self, domain):
         score = {'domain': domain['domain'], 'subdomain_scores': list()}
-
-        if "cyhy_stakeholder" in domain:
-            self.__cyhy_stakeholder = domain["cyhy_stakeholder"]
 
         if domain['live']:
             score['live_bool'] = True
@@ -444,11 +440,7 @@ class ReportGenerator(object):
         if not self.__debug:
             src_filename = os.path.join(temp_working_dir, REPORT_PDF)
             datestamp = self.__generated_time.strftime('%Y-%m-%d')
-
-            if self.__cyhy_stakeholder:
-                dest_dir = "."
-            else:
-                dest_dir = "../pshtt_non-cyhy_reports"
+            dest_dir = "."
 
             if self.__agency_id is not None:
                 dest_filename = "{}/cyhy-{}-{}-https-report.pdf".format(


### PR DESCRIPTION
This pull request goes along with dhs-ncats/saver#13.

As mentioned [here](https://github.com/dhs-ncats/saver/pull/12#issuecomment-377308432):
> I'm also interested in removing the noncyhy.csv file. As long as I ensure that all entries in that file appear in agencies.csv, the data will be saved in the database, the agency will appear in unique-agencies.csv, and the HTTPS and Trustworthy Email reports should be generated. (I will do a test to verify this.)

> Assuming that is the case, the only other thing noncyhy.csv is used for is to populate a field in the scan database that is in turn used to separate HTTPS reports into two directories (pshtt_reports and pshtt_non-cyhy_reports). I don't think we care about separating the reports into two such directories (particularly since we don't do it for Trustworthy Email reports), so I think we can do away with this.