### PR TITLE
Change Docker Hub organization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 
 env:
   global:
-    - IMAGE_NAME=dhsncats/pshtt_reporter
+    - IMAGE_NAME=cisagov/pshtt_reporter
     - DOCKER_USER=jsf9k
     - secure: "CQqWTdBgIsfDTWy5v99YVwPPqunjGRizq/lTlpP4JMu7JFUsZ7ht69XAXEsaQIVT/cqxmTaa03Zgz+k6Cq4XVtV+MmgMpwNTtTt3lEh7TZGNNU6pTB/1GOC0Ak0U95JpZGELsIxKHoe85KHqzjs6eMP9bYK2ESyfETpoGjq7rVYSojUkBkj4AKu6/MxzOaLe5LVHn7yqVDZIK2CQzTq/qvJ47ZewNuHuO4aPbflWB0U3XtmiORNKkPtB/jebxSO7EJnZnsflbqbFb7uUp1UDX7CoRUYb7NL+wV2dqd7MkC92zxEhKndH26V8V3IsApfPXnaxSoDISWjmGxfZ8sdqIljVyPsNyaY8YPuBNVJX8heOEAvqo2gGtbzoNlgAC74UjoUuGGYk7HIbNLchFE8S/iCye/GydlzpXs2mLGMge0jA3MQTNE4R+x2oJukcYtd4n7ubsprzxuuo+onfdoWb1VEz2enCvEYr5suZj7bYxN/rh52UzWz0rdvdTChqjVuMPhmABFdwjIWPe59Hh0Ad6VC18aswO8q902paM/SBRyVCzmJ8q5RWG6cEj/yHG1tvbublVnWjwW69jKWIMm+XWmmeMNGLB742rPDu7JNtadxVlndPwRVCnsCHWhNCnm+A5D2l+6nCqpT4Ow4/jle5LLnvwm37XjC0lcSQpW+KE2M="
 

--- a/travis_scripts/build_docker_image.sh
+++ b/travis_scripts/build_docker_image.sh
@@ -4,5 +4,7 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
-version=$(./bump_version.sh show)
+# semver uses a plus character for the build number (if present).
+# This is invalid for a Docker tag, so we replace it with a minus.
+version=$(./bump_version.sh show|sed "s/+/-/")
 docker build -t "$IMAGE_NAME":"$version" .

--- a/travis_scripts/deploy_to_docker_hub.sh
+++ b/travis_scripts/deploy_to_docker_hub.sh
@@ -5,5 +5,7 @@ set -o errexit
 set -o pipefail
 
 echo "$DOCKER_PW" | docker login -u "$DOCKER_USER" --password-stdin
-version=$(./bump_version.sh show)
+# semver uses a plus character for the build number (if present).
+# This is invalid for a Docker tag, so we replace it with a minus.
+version=$(./bump_version.sh show|sed "s/+/-/")
 docker push "$IMAGE_NAME":"$version"


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description

Rename the Docker image so that it belongs to the cisagov organization instead of the dhsncats organization.

Also update some scripts that are used by TravisCI so that they can handle build numbers in the version string.  (Stolen from cisagov/scanner.)

## 💭 Motivation and Context

We are migrating to the cisagov organization.

## 🧪 Testing

The TravisCI checks pass.

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
