### PR TITLE
Update OCSP/CRL List Link

### DIFF
--- a/report/https_scan_report.mustache
+++ b/report/https_scan_report.mustache
@@ -413,7 +413,7 @@ BOD 18-01 includes
 practice only used internally.  An exception is made for domains used
 exclusively for Online Certificate Status Protocol (OCSP), which can
 be excluded from the BOD 18-01 requirements by adding them to
-\href{https://github.com/GSA/data/blob/master/dotgov-websites/ocsp-crl.csv}{this
+\href{https://github.com/cisagov/dotgov-data/blob/main/dotgov-websites/ocsp-crl.csv}{this
   CSV file}.  Such domains appear in the table below followed by an
 asterisk, and their scores \emph{are not} included as part of the BOD
 18-01 compliance calculations.\\~\\


### PR DESCRIPTION
It looks like the report is still referencing the old OCSP/CRL list that is over on GSA's github we previously had been referencing prior to the shift of the DotGov program.  We should make sure we are pointing at the list we maintain here at CISAgov.