### PR TITLE
Let Renovate handle dependencies that Dependabot cannot

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -29,6 +29,16 @@
       // architectures.  In rare cases this is not the case.
       registryUrlTemplate: "https://deb.debian.org/debian?suite=trixie&components=main,contrib,non-free&binaryArch=amd64",
     },
+    {
+      customType: "regex",
+      datasourceTemplate: "github-releases",
+      depNameTemplate: "cisagov/guacscanner",
+      managerFilePatterns: ["/^src/Pipfile$/"],
+      matchStrings: [
+        "cisagov/mongo-db-from-config/archive/(?<currentValue>\\S+).tar.gz",
+      ],
+      versioningTemplate: "semver-coerced", // handles the leading `v`
+    },
   ],
   dependencyDashboard: true,
   enabledManagers: ["custom.regex"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,37 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  constraints: {
+    // Must be kept in sync with the major-minor version of Python
+    // being used in the base containers in the Dockerfile.
+    python: "==3.14",
+  },
+
+  customManagers: [
+    {
+      customType: "regex",
+      datasourceTemplate: "pypi",
+      managerFilePatterns: ["Dockerfile"],
+      matchStrings: [
+        "#\\s*renovate:\\s*datasource=pypi\\s+depName=(?<depName>\\S+)\\s*(ENV|ARG)?\\s*.+_VERSION=(?<currentValue>\\S+)",
+      ],
+    },
+    {
+      customType: "regex",
+      datasourceTemplate: "deb",
+      managerFilePatterns: ["Dockerfile"],
+      matchStrings: [
+        "#\\s*renovate:\\s*datasource=deb\\s+depName=(?<depName>\\S+)\\s*(ENV|ARG)?\\s*.+_VERSION=(?<currentValue>\\S+)",
+      ],
+      // The suite here must be kept in sync with the Debian release
+      // used in the base containers in the Dockerfile.
+      //
+      // Note also that the sae package version is offered for all
+      // architectures.  In rare cases this is not the case.
+      registryUrlTemplate: "https://deb.debian.org/debian?suite=trixie&components=main,contrib,non-free&binaryArch=amd64",
+    },
+  ],
+  dependencyDashboard: true,
+  enabledManagers: ["custom.regex"],
+  extends: ["config:recommended"],
+  labels: ["dependencies"],
+}

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -25,7 +25,7 @@
       // The suite here must be kept in sync with the Debian release
       // used in the base containers in the Dockerfile.
       //
-      // Note also that the sae package version is offered for all
+      // Note also that the same package version is offered for all
       // architectures.  In rare cases this is not the case.
       registryUrlTemplate: "https://deb.debian.org/debian?suite=trixie&components=main,contrib,non-free&binaryArch=amd64",
     },

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,11 @@ ENV CISA_HOME="/home/${CISA_USER}"
 ENV VIRTUAL_ENV="${CISA_HOME}/.venv"
 
 # Versions of the Python packages installed directly
+# renovate: datasource=pypi depName=pip
 ENV PYTHON_PIP_VERSION=26.2.1
+# renovate: datasource=pypi depName=pipenv
 ENV PYTHON_PIPENV_VERSION=2026.7.1
+# renovate: datasource=pypi depName=setuptools
 ENV PYTHON_SETUPTOOLS_VERSION=84.0.0
 
 ###
@@ -75,19 +78,44 @@ RUN groupadd --system --gid ${CISA_GID} ${CISA_GROUP} \
     && useradd --system --uid ${CISA_UID} --gid ${CISA_GROUP} --comment "${CISA_USER} user" ${CISA_USER}
 
 ###
-# Install everything we need
+# Install everything we need.
+#
+# Note that the suite name must be kept in sync with the version of
+# Debian being used in the base containers.
 ###
-ENV DEPS="fontconfig=2.15.0-2.3 \
-    lmodern=2.005-1 \
-    redis-tools=5:8.0.2-3+deb13u2 \
-    texlive-latex-base=2024.20250309-1 \
-    texlive-latex-recommended=2024.20250309-1 \
-    texlive-latex-extra=2024.20250309-2 \
-    texlive-xetex=2024.20250309-1 \
-    texlive-science=2024.20250309-2 \
-    unzip=6.0-29 \
-    wget=1.25.0-2 \
-    xzdec=5.8.1-1+deb13u1"
+# renovate: datasource=deb depName=fontconfig
+ENV FONTCONFIG_VERSION=2.15.0-2.3
+# renovate: datasource=deb depName=lmodern
+ENV LMODERN_VERSION=2.005-1
+# renovate: datasource=deb depName=redis-tools
+ENV REDIS_TOOLS_VERSION=5:8.0.2-3+deb13u2
+# renovate: datasource=deb depName=texlive-latex-base
+ENV TEXLIVE_LATEX_BASE_VERSION=2024.20250309-1
+# renovate: datasource=deb depName=texlive-latex-extra
+ENV TEXLIVE_LATEX_EXTRA_VERSION=2024.20250309-2
+# renovate: datasource=deb depName=texlive-latex-recommended
+ENV TEXLIVE_LATEX_RECOMMENDED_VERSION=2024.20250309-1
+# renovate: datasource=deb depName=texlive-science
+ENV TEXLIVE_SCIENCE_VERSION=2024.20250309-2
+# renovate: datasource=deb depName=texlive-xetex
+ENV TEXLIVE_XETEX_VERSION=2024.20250309-1
+# renovate: datasource=deb depName=unzip
+ENV UNZIP_VERSION=6.0-29
+# renovate: datasource=deb depName=wget
+ENV WGET_VERSION=1.25.0-2
+# renovate: datasource=deb depName=xzdec
+ENV XZDEC_VERSION=5.8.1-1+deb13u1
+ENV DEPS="fontconfig=${FONTCONFIG_VERSION} \
+    lmodern=${LMODERN_VERSION} \
+    redis-tools=${REDIS_TOOLS_VERSION} \
+    texlive-latex-base=${TEXLIVE_LATEX_BASE_VERSION} \
+    texlive-latex-extra=${TEXLIVE_LATEX_EXTRA_VERSION} \
+    texlive-latex-recommended=${TEXLIVE_LATEX_RECOMMENDED_VERSION} \
+    texlive-science=${TEXLIVE_SCIENCE_VERSION} \
+    texlive-xetex=${TEXLIVE_XETEX_VERSION} \
+    unzip=${UNZIP_VERSION} \
+    wget=${WGET_VERSION} \
+    xzdec=${XZDEC_VERSION}"
 RUN apt update --quiet --quiet \
     && apt install --quiet --quiet --yes \
     --no-install-recommends --no-install-suggests \


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds a Renovate configuration and some Renovate annotations to allow Renovate to manage some dependencies that Dependabot cannot handle.

## 💭 Motivation and context ##

These dependencies were being updated manually before, so this is an improvement.

## 🧪 Testing ##

I verified that the Renovate config is valid and functions as expected by performing a dry run of Renovate locally.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.