### PR TITLE
Fix typo in Renovate configuration

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -32,7 +32,7 @@
     {
       customType: "regex",
       datasourceTemplate: "github-releases",
-      depNameTemplate: "cisagov/guacscanner",
+      depNameTemplate: "cisagov/mongo-db-from-config",
       managerFilePatterns: ["/^src/Pipfile$/"],
       matchStrings: [
         "cisagov/mongo-db-from-config/archive/(?<currentValue>\\S+).tar.gz",


### PR DESCRIPTION
## 🗣 Description ##

This pull request fixes a typo in the Renovate configuration.

## 💭 Motivation and context ##

The Renovate configuration will cause incorrect PRs to be created if it is not fixed.

## 🧪 Testing ##

:eyes: 

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.